### PR TITLE
[BUGFIX] fatal error when request engine is a dependency proxy

### DIFF
--- a/Classes/RobertLemke/Akismet/Service.php
+++ b/Classes/RobertLemke/Akismet/Service.php
@@ -62,6 +62,9 @@ class Service {
 	 * @return void
 	 */
 	public function initializeObject() {
+		if ($this->browserRequestEngine instanceof \TYPO3\Flow\Object\DependencyInjection\DependencyProxy) {
+			$this->browserRequestEngine->_activateDependency();
+		}
 		$this->browser->setRequestEngine($this->browserRequestEngine);
 	}
 


### PR DESCRIPTION
If the request engine for the browser is a dependency proxy, it is now
activated before being passed to setRequestEngine() during object
initialization.
